### PR TITLE
Velocity és Direction property a AutomatedCar-hoz

### DIFF
--- a/src/AutomatedCar/Helpers/Speed.cs
+++ b/src/AutomatedCar/Helpers/Speed.cs
@@ -42,5 +42,10 @@
         {
             return this.PixelsPerTick;
         }
+
+        public double InPixelsPerSecond()
+        {
+            return this.PixelsPerTick * GameBase.TicksPerSecond;
+        }
     }
 }

--- a/src/AutomatedCar/Models/AutomatedCar.cs
+++ b/src/AutomatedCar/Models/AutomatedCar.cs
@@ -3,10 +3,16 @@ namespace AutomatedCar.Models
     using SystemComponents.Sensors;
     using Avalonia.Media;
     using SystemComponents;
+    using global::AutomatedCar.Helpers;
+    using System.Numerics;
+    using Avalonia;
+    using System;
 
     public class AutomatedCar : Car
     {
         private VirtualFunctionBus virtualFunctionBus;
+        private Speed velocity;
+        private Vector2 direction;
 
         public AutomatedCar(int x, int y, string filename)
             : base(x, y, filename)
@@ -17,9 +23,46 @@ namespace AutomatedCar.Models
 
         public VirtualFunctionBus VirtualFunctionBus { get => this.virtualFunctionBus; }
 
+        /// <summary>
+        /// The revolution of the engine in the car.
+        /// </summary>
         public int Revolution { get; set; }
 
-        public int Velocity { get; set; }
+        /// <summary>
+        /// The speed of the car.
+        /// </summary>
+        public Speed Velocity
+        {
+            get
+            {
+                return this.velocity;
+            }
+
+            set
+            {
+                this.velocity = value;
+                this.Speed = (int)value.InPixelsPerSecond();
+            }
+        }
+
+        /// <summary>
+        /// The direction in which the car is facing. Always has the length of 1.
+        /// </summary>
+        public Vector2 Direction
+        {
+            get
+            {
+                return this.direction;
+            }
+
+            set
+            {
+                this.direction = Vector2.Normalize(value);
+
+                float angleRadians = (float)Math.Atan2(value.Y, value.X);
+                this.Rotation = angleRadians * (180 / Math.PI);
+            }
+        }
 
         public PolylineGeometry Geometry { get; set; }
 

--- a/src/AutomatedCar/Models/Car.cs
+++ b/src/AutomatedCar/Models/Car.cs
@@ -8,6 +8,6 @@ namespace AutomatedCar.Models
         }
 
         /// <summary>Gets or sets Speed in px/s.</summary>
-        public int Speed { get; set; }
+        public int Speed { get; protected set; }
     }
 }


### PR DESCRIPTION
Minimális kód, hogy az #50 és #60 issue-kat egyszerre tudjuk fejleszteni.

- Hozzáadtam az `AutomatedCar`-hoz a `Direction` property-t, ami az autó irányát jelzi. (nem vagyok biztos benne, hogy szükség van rá, hiszen a `WorldObject.Rotation` is tárolja ezt, viszont a kanyarodásnál lehet szükségem lesz rá)
- Az `AutomatedCar.Velocity` mezőt `Speed` típusra módosítottam, és settelésnél beállítja a `Car.Speed`-et. (nem akartam törölni a `Car.Speed`-et, mert máshol már használatban van)
- Hozzáadtam a `Speed`-hez egy `InPixelsPerSecond()` metódust.
- `Car.Speed` mező setterét `protected`-re állítottam, hogy még véletlenül se azt módosítsuk, hanem az `AutomatedCar.Velocity`-t.