### PR TITLE
Akció kérés implementálása

### DIFF
--- a/src/AutomatedCar/App.xaml.cs
+++ b/src/AutomatedCar/App.xaml.cs
@@ -92,10 +92,8 @@ namespace AutomatedCar
         private void AddControlledCarsTo(World world)
         {
             var controlledCar = this.CreateControlledCar(480, 1425, 0, "car_1_white.png");
-            var controlledCar2 = this.CreateControlledCar(4250, 1420, -90, "car_1_red.png");
 
             world.AddControlledCar(controlledCar);
-            world.AddControlledCar(controlledCar2);
         }
 
         private void AddNpcsTo(World world)

--- a/src/AutomatedCar/Helpers/InputRequestType.cs
+++ b/src/AutomatedCar/Helpers/InputRequestType.cs
@@ -1,0 +1,34 @@
+﻿namespace AutomatedCar.Helpers
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// The type of inputs the different system components can request.
+    /// </summary>
+    public enum InputRequestType
+    {
+        /// <summary>
+        /// Steer the steering wheel left.
+        /// </summary>
+        SteerLeft,
+
+        /// <summary>
+        /// Steer the steering wheel right.
+        /// </summary>
+        SteerRight,
+
+        /// <summary>
+        /// Push the throttle pedal down.
+        /// </summary>
+        Throttle,
+
+        /// <summary>
+        /// Push the brake pedal down.
+        /// </summary>
+        Brake,
+    }
+}

--- a/src/AutomatedCar/Helpers/InputRequesterComponent.cs
+++ b/src/AutomatedCar/Helpers/InputRequesterComponent.cs
@@ -1,0 +1,34 @@
+﻿namespace AutomatedCar.Helpers
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Enum for the system components that can request input from the automated car.
+    /// </summary>
+    public enum InputRequesterComponent
+    {
+        /// <summary>
+        /// The driver (user) of the car (software).
+        /// </summary>
+        Driver = 0,
+
+        /// <summary>
+        /// The emergency braking system.
+        /// </summary>
+        EmergencyBrake = 1,
+
+        /// <summary>
+        /// The lane keeping assist system.
+        /// </summary>
+        LaneKeepingAssist = 2,
+
+        /// <summary>
+        /// The cruise control system.
+        /// </summary>
+        CruiseControl = 3,
+    }
+}

--- a/src/AutomatedCar/ViewModels/CourseDisplayViewModel.cs
+++ b/src/AutomatedCar/ViewModels/CourseDisplayViewModel.cs
@@ -8,6 +8,7 @@ namespace AutomatedCar.ViewModels
 {
     using Avalonia.Controls;
     using Models;
+    using Newtonsoft.Json.Linq;
     using System;
     using Visualization;
 
@@ -49,12 +50,12 @@ namespace AutomatedCar.ViewModels
 
         internal void ThrottleOnSet(bool value)
         {
-            World.Instance.ControlledCar.ThrottleOn = value;
+            World.Instance.ControlledCar.RequestInput(Helpers.InputRequesterComponent.Driver, Helpers.InputRequestType.Throttle, value);
         }
 
         internal void BrakeOnSet(bool value)
         {
-            World.Instance.ControlledCar.BrakeOn = value;
+            World.Instance.ControlledCar.RequestInput(Helpers.InputRequesterComponent.Driver, Helpers.InputRequestType.Brake, value);
         }
 
         public void ToggleDebug()
@@ -84,13 +85,14 @@ namespace AutomatedCar.ViewModels
 
         internal void SetSteeringLeft(bool v)
         {
-            World.Instance.ControlledCar.SteeringLeft = v;
+            World.Instance.ControlledCar.RequestInput(Helpers.InputRequesterComponent.Driver, Helpers.InputRequestType.SteerLeft, v);
         }
 
         internal void SetSteeringRight(bool v)
         {
-            World.Instance.ControlledCar.SteeringRight = v;
+            World.Instance.ControlledCar.RequestInput(Helpers.InputRequesterComponent.Driver, Helpers.InputRequestType.SteerRight, v);
         }
+
         private void OnControlledCarPositionChanged(object sender, PropertyChangedEventArgs e)
         {
             if (e.PropertyName == nameof(WorldObject.X) || e.PropertyName == nameof(WorldObject.Y))


### PR DESCRIPTION
#59 

Implementáltam az akció kérést. Minden komponens adhat inputot az autónak, viszont az autó eldönti magának, hogy eleget tesz-e a kérésnek.

A prioritások a `InputRequesterComponent` enumban vannak, ha úgy döntünk, hogy rossz a sorrend akkor egyszerűen át lehet variálni. Jelenleg erre állítottam be (kisebb szám nagyobb prioritás):

- Driver = 0,
- EmergencyBrake = 1,
- LaneKeepingAssist = 2,
- CruiseControl = 3,

Minden komponens kérhet bármilyen inputot, nem hiszem, hogy akárki abuzálni fogja a funkciót, de ha mégis akkor az `AutomatedCar.RequestInput()`-ot kell módosítani. (bár ez eléggé lassítani fog a programon)

Ezen kívül:

- Töröltem a másik irányított autót
- `Obsolete`-re raktam a `ReverseOn`t, ezt majd a váltó állásából lehet majd vizsgálni, úgyhogy nincs rá szükség, csak nem akartam bajlódni a törlésével